### PR TITLE
fix: Ignore folders used by CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist
 /build
+/git-cliff
+/__tools


### PR DESCRIPTION
So goreleaser stops complaining